### PR TITLE
Add option to install as .deb package instead of the pip package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,9 @@
 #    Boolean flag to install pip or not
 #    Default: true
 #
+#  [$provider]
+#    One of "pip" or "apt"
+#
 #  [$proxy]
 #    String proxy variable for use with EPEL module
 #    Default: undef
@@ -59,20 +62,33 @@ class awscli (
   $manage_epel      = true,
   $install_pkgdeps  = true,
   $install_pip      = true,
+  $provider         = 'pip',
   $proxy            = $awscli::params::proxy,
   $install_options  = $awscli::params::install_options,
 ) inherits awscli::params {
-  class { '::awscli::deps':
-    proxy => $proxy,
-  }
 
-  package { 'awscli':
-    ensure          => $version,
-    provider        => 'pip',
-    install_options => $install_options,
-    require         => [
-      Package[$pkg_pip],
-      Class['awscli::deps'],
-    ],
-  }
+  case $provider {
+    'pip': {
+      class { '::awscli::deps':
+        proxy => $proxy,
+      }
+
+      package { 'awscli':
+        ensure          => $version,
+        provider        => 'pip',
+        install_options => $install_options,
+        require         => [
+          Package[$pkg_pip],
+          Class['awscli::deps'],
+        ],
+      }
+    }
+
+    'apt' : {
+      package { 'awscli':
+        ensure   => 'latest',
+        provider => 'apt',
+      }
+    }
+  } 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -41,7 +41,7 @@
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [ "10.04", "12.04", "14.04", "16.04" ]
+      "operatingsystemrelease": [ "10.04", "12.04", "14.04", "16.04", "18.04" ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
Adds a new `provider` option that defaults to `pip` but could be set to `apt`.

Addresses #60.