### PR TITLE
do not show diff for credentials file

### DIFF
--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -122,11 +122,12 @@ define awscli::profile(
   if ! $skip_credentials {
     if !defined(Concat["${homedir_real}/.aws/credentials"]) {
       concat { "${homedir_real}/.aws/credentials":
-        ensure  => 'present',
-        owner   => $user,
-        group   => $group_real,
-        mode    => '0600',
-        require => File["${homedir_real}/.aws"],
+        ensure    => 'present',
+        owner     => $user,
+        group     => $group_real,
+        mode      => '0600',
+        show_diff => false,
+        require   => File["${homedir_real}/.aws"],
       }
     }
 


### PR DESCRIPTION
Currently credentials are being written in plaintext to syslog any time the credentials file changes, which is not ideal. This PR suppresses output when modifying credential files so that this will no longer happen.

I have a temporary solution in place using a resource collector to disable show_diff, but this seems like it should probably be the default behavior NOT to display the password in the log.