### PR TITLE
Replace 'stahnma-epel' by 'puppet-epel'

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,8 +2,8 @@
 fixtures:
   forge_modules:
     epel:
-      repo: "stahnma/epel"
-      ref: "1.2.2"
+      repo: "puppet/epel"
+      ref: "3.0.1"
     concat:
       repo: "puppetlabs/concat"
       ref: "4.0.0"

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -10,4 +10,3 @@ DEPENDENCIES
   puppetlabs-concat (< 5.0.0, >= 2.0.0)
   puppetlabs-stdlib (< 5.0.0, >= 4.0.0)
   puppet-epel (< 3.0.2, >= 3.0.0)
-

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -9,4 +9,4 @@ FORGE
 DEPENDENCIES
   puppetlabs-concat (< 5.0.0, >= 2.0.0)
   puppetlabs-stdlib (< 5.0.0, >= 4.0.0)
-  puppet-epel (< 3.0.2, >= 3.0.0)
+  puppet-epel (< 3.99.0, >= 3.0.0)

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -4,11 +4,10 @@ FORGE
     puppetlabs-concat (2.2.1)
       puppetlabs-stdlib (< 5.0.0, >= 4.2.0)
     puppetlabs-stdlib (4.16.0)
-    stahnma-epel (1.2.2)
-      puppetlabs-stdlib (>= 3.0.0)
+    puppet-epel (3.0.1)
 
 DEPENDENCIES
   puppetlabs-concat (< 5.0.0, >= 2.0.0)
   puppetlabs-stdlib (< 5.0.0, >= 4.0.0)
-  stahnma-epel (< 2.0.0, >= 1.0.0)
+  puppet-epel (< 3.0.2, >= 3.0.0)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,14 +68,14 @@ class awscli (
 ) inherits awscli::params {
 
   case $provider {
-    'pip': {
+    'pip','pip3': {
       class { '::awscli::deps':
         proxy => $proxy,
       }
 
       package { 'awscli':
         ensure          => $version,
-        provider        => 'pip',
+        provider        => $provider,
         install_options => $install_options,
         require         => [
           Package[$pkg_pip],

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jdowning-awscli",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "Justin Downing",
   "summary": "Install awscli",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -84,7 +84,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.4.3 < 5.0.0"
+      "version_requirement": ">= 3.4.3 <= 6.18"
     }
   ],
   "description": "Install awscli",

--- a/metadata.json
+++ b/metadata.json
@@ -9,8 +9,8 @@
   "issues_url": "https://github.com/jdowning/puppet-awscli/issues",
   "dependencies": [
     {
-      "name": "stahnma/epel",
-      "version_requirement": ">= 1.0.0 <2.0.0"
+      "name": "puppet/epel",
+      "version_requirement": ">= 3.0.0 <3.0.2"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet/epel",
-      "version_requirement": ">= 3.0.0 <3.0.2"
+      "version_requirement": ">= 3.0.0 <3.99.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -84,7 +84,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.4.3 <= 6.18"
+      "version_requirement": ">= 3.4.3 <= 6.19.0"
     }
   ],
   "description": "Install awscli",

--- a/metadata.json
+++ b/metadata.json
@@ -84,7 +84,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.4.3 <= 6.19.0"
+      "version_requirement": ">= 3.4.3 <= 6.99.0"
     }
   ],
   "description": "Install awscli",


### PR DESCRIPTION
Accepting and merging this request will:

  - support the use of `puppet-epel` instead of DEPRECATED `stahnma-epel` module;
    - there we have an official module maintained by [Vox Pupuli](https://github.com/voxpupuli/puppet-epel)
  - explicitly allow one to use this module with **CentOS 8**;
  - make possible to have `pip3` as provider;
  - get this module to work with **Puppet** versions greater than 4;
  - it means that we support >= 5.0.0.

By merging this request we should fix the following issues:

  - #67 
  - #68 

Its changes were minimal, and avoided removing any particular file (like Puppetfile.lock).